### PR TITLE
Fix serialization MaxDepth for Folder and Processing

### DIFF
--- a/src/Entity/Pia/Folder.php
+++ b/src/Entity/Pia/Folder.php
@@ -99,7 +99,6 @@ class Folder implements Timestampable
     /**
      * @ORM\OneToMany(targetEntity="Processing", mappedBy="folder",cascade={"remove"})
      * @JMS\Groups({"Default", "Export"})
-     * @JMS\MaxDepth(2)
      *
      * @var Collection|Processing[]
      */

--- a/src/Entity/Pia/Folder.php
+++ b/src/Entity/Pia/Folder.php
@@ -99,6 +99,7 @@ class Folder implements Timestampable
     /**
      * @ORM\OneToMany(targetEntity="Processing", mappedBy="folder",cascade={"remove"})
      * @JMS\Groups({"Default", "Export"})
+     * @JMS\MaxDepth(2)
      *
      * @var Collection|Processing[]
      */

--- a/src/Entity/Pia/Processing.php
+++ b/src/Entity/Pia/Processing.php
@@ -122,7 +122,6 @@ class Processing
     /**
      * @ORM\OneToMany(targetEntity="Pia", mappedBy="processing")
      * @JMS\Groups({"Default", "Export"})
-     * @JMS\MaxDepth(1)
      *
      * @var Collection|Pia[]
      */

--- a/src/Entity/Pia/Processing.php
+++ b/src/Entity/Pia/Processing.php
@@ -122,6 +122,7 @@ class Processing
     /**
      * @ORM\OneToMany(targetEntity="Pia", mappedBy="processing")
      * @JMS\Groups({"Default", "Export"})
+     * @JMS\Exclude()
      *
      * @var Collection|Pia[]
      */
@@ -311,6 +312,17 @@ class Processing
             throw new \InvalidArgumentException(sprintf('ProcessingDataType « %s » does not belong to Processing « #%d »', $processingDataType->getId(), $this->getId()));
         }
         $this->processingDataTypes->removeElement($processingDataType);
+    }
+
+    /**
+     * @JMS\VirtualProperty("piasCount")
+     * @JMS\Groups({"Default", "Export"})
+     *
+     * @return int
+     */
+    public function getPiasCount(): int
+    {
+        return $this->pias->count();
     }
 
     /**


### PR DESCRIPTION
### Summary

When displaying folders on front, the processings fields was always empty. It was the same problem when displaying processings, the associated pias where empty.

So removing maxDepth on these two fields allow use to display related pias