### PR TITLE
Fix processing serialization

### DIFF
--- a/src/Controller/Pia/ProcessingController.php
+++ b/src/Controller/Pia/ProcessingController.php
@@ -21,6 +21,7 @@ use Swagger\Annotations as Swg;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use PiaApi\DataHandler\RequestDataHandler;
 
 class ProcessingController extends RestController
 {
@@ -97,7 +98,6 @@ class ProcessingController extends RestController
         return $this->showEntity($id);
     }
 
-
     /**
      * Creates a Processing.
      *
@@ -134,7 +134,6 @@ class ProcessingController extends RestController
 
         return $this->view($processing, Response::HTTP_OK);
     }
-
 
     /**
      * Updates a processing.

--- a/src/Controller/Pia/ProcessingController.php
+++ b/src/Controller/Pia/ProcessingController.php
@@ -10,10 +10,8 @@
 
 namespace PiaApi\Controller\Pia;
 
-use PiaApi\DataHandler\RequestDataHandler;
 use PiaApi\Services\ProcessingService;
 use PiaApi\Entity\Pia\Processing;
-
 use FOS\RestBundle\Controller\Annotations as FOSRest;
 use FOS\RestBundle\View\View;
 use Nelmio\ApiDocBundle\Annotation as Nelmio;
@@ -21,7 +19,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Swagger\Annotations as Swg;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 class ProcessingController extends RestController

--- a/src/Entity/Pia/Folder.php
+++ b/src/Entity/Pia/Folder.php
@@ -99,7 +99,6 @@ class Folder implements Timestampable
     /**
      * @ORM\OneToMany(targetEntity="Processing", mappedBy="folder",cascade={"remove"})
      * @JMS\Groups({"Default", "Export"})
-     * @JMS\MaxDepth(2)
      *
      * @var Collection|Processing[]
      */

--- a/src/Entity/Pia/Folder.php
+++ b/src/Entity/Pia/Folder.php
@@ -99,6 +99,7 @@ class Folder implements Timestampable
     /**
      * @ORM\OneToMany(targetEntity="Processing", mappedBy="folder",cascade={"remove"})
      * @JMS\Groups({"Default", "Export"})
+     * @JMS\MaxDepth(2)
      *
      * @var Collection|Processing[]
      */

--- a/src/Entity/Pia/Processing.php
+++ b/src/Entity/Pia/Processing.php
@@ -122,7 +122,6 @@ class Processing
     /**
      * @ORM\OneToMany(targetEntity="Pia", mappedBy="processing")
      * @JMS\Groups({"Default", "Export"})
-     * @JMS\MaxDepth(1)
      *
      * @var Collection|Pia[]
      */

--- a/src/Entity/Pia/Processing.php
+++ b/src/Entity/Pia/Processing.php
@@ -122,6 +122,7 @@ class Processing
     /**
      * @ORM\OneToMany(targetEntity="Pia", mappedBy="processing")
      * @JMS\Groups({"Default", "Export"})
+     * @JMS\Exclude()
      *
      * @var Collection|Pia[]
      */
@@ -311,6 +312,17 @@ class Processing
             throw new \InvalidArgumentException(sprintf('ProcessingDataType « %s » does not belong to Processing « #%d »', $processingDataType->getId(), $this->getId()));
         }
         $this->processingDataTypes->removeElement($processingDataType);
+    }
+
+    /**
+     * @JMS\VirtualProperty("piasCount")
+     * @JMS\Groups({"Default", "Export"})
+     *
+     * @return int
+     */
+    public function getPiasCount(): int
+    {
+        return $this->pias->count();
     }
 
     /**

--- a/src/Form/User/DataTransformer/UserProfileTransformer.php
+++ b/src/Form/User/DataTransformer/UserProfileTransformer.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright (C) 2015-2018 Libre Informatique
  *
@@ -6,6 +7,7 @@
  * For the full copyright and license information, please view the LICENSE.md
  * file that was distributed with this source code.
  */
+
 namespace PiaApi\Form\User\DataTransformer;
 
 use Symfony\Component\Form\DataTransformerInterface;
@@ -19,6 +21,7 @@ class UserProfileTransformer implements DataTransformerInterface
      * @var RegistryInterface
      */
     protected $doctrine;
+
     /**
      * @param RegistryInterface $doctrine
      */
@@ -26,6 +29,7 @@ class UserProfileTransformer implements DataTransformerInterface
     {
         $this->doctrine = $doctrine;
     }
+
     /**
      * @param UserProfile $profile
      *
@@ -41,10 +45,13 @@ class UserProfileTransformer implements DataTransformerInterface
             'firstName'     => $profile->getFirstName(),
             'lastName'      => $profile->getLastName(),
           ];
+
             return $array;
         }
+
         return $profile;
     }
+
     /**
      * @param string $value
      *
@@ -53,7 +60,7 @@ class UserProfileTransformer implements DataTransformerInterface
     public function reverseTransform($value)
     {
         $profile = new UserProfile();
-        
+
         $profileRepository = $this->doctrine->getRepository(UserProfile::class);
 
         if (isset($value['id'])) {
@@ -65,7 +72,7 @@ class UserProfileTransformer implements DataTransformerInterface
         if (isset($value['lastName'])) {
             $profile->setLastName($value['lastName']);
         }
-       
+
         return $profile;
     }
 }

--- a/src/Repository/ProcessingRepository.php
+++ b/src/Repository/ProcessingRepository.php
@@ -12,10 +12,8 @@ namespace PiaApi\Repository;
 
 use PiaApi\Entity\Pia\Processing;
 use PiaApi\Entity\Pia\Structure;
-
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Pagerfanta\PagerfantaInterface;
 use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Pagerfanta;
 
@@ -48,5 +46,4 @@ class ProcessingRepository extends ServiceEntityRepository
 
         return $pagerfanta->getCurrentPageResults()->getArrayCopy();
     }
-
 }

--- a/src/Security/Role/RoleHierarchy.php
+++ b/src/Security/Role/RoleHierarchy.php
@@ -41,13 +41,13 @@ class RoleHierarchy
         }
         $this->roleHierarchy = $roleHierarchy;
     }
-    
+
     protected function getUserRoles(User $user): array
     {
         $userRoles = array_map(function ($roleName) {
             return new Role($roleName);
         }, $user->getRoles());
-        
+
         return $userRoles;
     }
 
@@ -55,18 +55,18 @@ class RoleHierarchy
     {
         // Core roleHierarchy needs a Role array but we use string array
         $userRoles = $this->getUserRoles($user);
-      
+
         $reachableRoleNames = array_map(function ($role) {
             return $role->getRole();
         }, $this->roleHierarchy->getReachableRoles($userRoles));
-        
+
         return $reachableRoleNames;
     }
 
     protected function getAcessibleRoles(User $user): array
     {
         $reachableRoleNames = $this->getReachableRoles($user);
-        
+
         return array_intersect($this->definedRoles, $reachableRoleNames);
     }
 
@@ -81,12 +81,12 @@ class RoleHierarchy
 
         return in_array($roleOrPermission, $reachableRoleNames);
     }
-    
+
     public function hasHigherRole(User $current_user, User $other_user)
     {
         $current_roles = $this->getAcessibleRoles($current_user);
         $other_roles = $this->getAcessibleRoles($other_user);
-        
+
         return count($current_roles) >= count($other_roles);
     }
 }

--- a/src/Services/ProcessingService.php
+++ b/src/Services/ProcessingService.php
@@ -21,16 +21,14 @@ class ProcessingService extends AbstractService
     }
 
     /**
-     * 
-     * @param string    $name
-     * @param Folder    $folder
-     * 
+     * @param string $name
+     * @param Folder $folder
+     *
      * @return Processing
      */
     public function createProcessing(string $name, Folder $folder): Processing
     {
         $processing = new Processing($name, $folder);
-
 
         return $processing;
     }

--- a/tests/api/130_ProcessingCest.php
+++ b/tests/api/130_ProcessingCest.php
@@ -25,10 +25,10 @@ class ProcessingCest
      * @var array
      */
     private $processingData = [
-        'name' => 'Processing CI',
-        'folder' => [],
-        'author' => 'Author 1',
-        'controllers' => 'Controller 1, Controller 2, Controller 3'
+        'name'        => 'Processing CI',
+        'folder'      => [],
+        'author'      => 'Author 1',
+        'controllers' => 'Controller 1, Controller 2, Controller 3',
     ];
 
     /**
@@ -46,7 +46,7 @@ class ProcessingCest
         'controllers'           => 'string',
         'non_eu_transfer'       => 'string|null',
         'processing_data_types' => 'array',
-        'pias'                  => 'array',
+        'pias_count'            => 'integer',
         'folder'                => 'array',
         'id'                    => 'integer',
         'created_at'            => 'string',
@@ -123,7 +123,6 @@ class ProcessingCest
             'name' => $name,
         ]);
     }
-
 
     /*
      * @depends create_processing_test


### PR DESCRIPTION
### Summary

When displaying folders on front, the processings fields was always empty. It was the same problem when displaying processings, the associated pias where empty.

So removing maxDepth on these two fields allow use to display related pias
