### PR TITLE
Cascading delete ProcessingDataType when deleting a Processing

### DIFF
--- a/src/Entity/Pia/Processing.php
+++ b/src/Entity/Pia/Processing.php
@@ -111,7 +111,7 @@ class Processing
     protected $nonEuTransfer;
 
     /**
-     * @ORM\OneToMany(targetEntity="ProcessingDataType", mappedBy="processing")
+     * @ORM\OneToMany(targetEntity="ProcessingDataType", mappedBy="processing", cascade={"remove"})
      * @JMS\Groups({"Default", "Export"})
      * @JMS\MaxDepth(2)
      *


### PR DESCRIPTION
Fix ForeignKeyConstraintViolation when deleting a Processing that have ProcessingDataType associated.